### PR TITLE
Switches link destinations around in the Games Index so that clicking…

### DIFF
--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -1,6 +1,6 @@
 <li>
-    <%= link_to game.name, game %>
-    <%= link_to " | Runs", speedruns_path(game.slug) %>
+    <%= link_to game.name, speedruns_path(game.slug) %>
+    <%= link_to " | Game Info", game%>
     <%= link_to " | Categories", runcats_path(game.slug) %>
 
     <% begin %>

--- a/app/views/speedruns/new.html.erb
+++ b/app/views/speedruns/new.html.erb
@@ -1,33 +1,41 @@
 <% provide(:title, "Submit a New Run for " + @game.name ) %>
 <h1>Submit a Run for <%= @game.name %></h1>
 
-<div class="row">
-    <div class="col-md-6 col-md-offset-3">
-        <%= form_for @speedrun do |f| %>
-            <%= render 'shared/error_messages', object: f.object %>
+<% if @game.runcats.count == 0 %>
+    <% if current_user.admin? %>
+        <h3>No categories exist for <%= @game.name %>. Make one <%= link_to "here!", new_game_runcat_path(@game.slug) %></h3>
+    <% else %>
+        <h3>No categories exist for <%= @game.name %>. Bug your local administrator to fix that.</h3>
+    <% end %>
+<% else %>
+    <div class="row">
+        <div class="col-md-6 col-md-offset-3">
+            <%= form_for @speedrun do |f| %>
+                <%= render 'shared/error_messages', object: f.object %>
 
-            <%= f.hidden_field :game_id, value: @game.id %>
-            <%= f.hidden_field :user_id, value: current_user.id %>
-            <%= f.hidden_field :is_valid, value: false %>
+                <%= f.hidden_field :game_id, value: @game.id %>
+                <%= f.hidden_field :user_id, value: current_user.id %>
+                <%= f.hidden_field :is_valid, value: false %>
 
-            <%= f.label :date_finished, "Date Finished" %>
-            <%= f.date_field :date_finished, class: 'form-control' %>
+                <%= f.label :date_finished, "Date Finished" %>
+                <%= f.date_field :date_finished, class: 'form-control' %>
 
-            <%= f.label :runcat_id, "Category" %>
-            <%= f.collection_select :runcat_id, @game.runcats.all, :id, :category, class: 'form-control' %>
-            <% # We're providing :runcat_id using the @game.runcats.all method looking for :id for value and :category for label %>
+                <%= f.label :runcat_id, "Category" %>
+                <%= f.collection_select :runcat_id, @game.runcats.all, :id, :category, class: 'form-control' %>
+                <% # We're providing :runcat_id using the @game.runcats.all method looking for :id for value and :category for label %>
 
-            <%= f.label :run_time_h, "Hours" %>
-            <%= f.number_field :run_time_h, min: 00, max: 9, value: 9, class: 'form-control' %>
-            <%= f.label :run_time_m, "Minutes" %>
-            <%= f.number_field :run_time_m, min: 00, max: 59, value: 59, class: 'form-control' %>
-            <%= f.label :run_time_s, "Seconds" %>
-            <%= f.number_field :run_time_s, min: 00, max: 59, value: 59, class: 'form-control' %>
+                <%= f.label :run_time_h, "Hours" %>
+                <%= f.number_field :run_time_h, min: 00, max: 9, value: 9, class: 'form-control' %>
+                <%= f.label :run_time_m, "Minutes" %>
+                <%= f.number_field :run_time_m, min: 00, max: 59, value: 59, class: 'form-control' %>
+                <%= f.label :run_time_s, "Seconds" %>
+                <%= f.number_field :run_time_s, min: 00, max: 59, value: 59, class: 'form-control' %>
 
-            <%= f.label :run_notes, "Run Notes" %>
-            <%= f.text_area :run_notes, class: 'form-control' %>
+                <%= f.label :run_notes, "Run Notes" %>
+                <%= f.text_area :run_notes, class: 'form-control' %>
 
-            <%= f.submit "Submit Speedrun", class: 'btn btn-primary' %>
-        <% end %>
+                <%= f.submit "Submit Speedrun", class: 'btn btn-primary' %>
+            <% end %>
+        </div>
     </div>
-</div>
+<% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,9 +9,9 @@ User.create!(name: "Example User", email: "adminman@boggygofast.org", password: 
 end
 
 # Set up games.
-Game.create!(name: "Metroid Prime", slug: "metroid_prime")
-Game.create!(name: "Ori and the Blind Forest: Definitive Edition", slug: "ori_bf_de")
-Game.create!(name: "Metroid 2: Samus Returns", slug: "metroid_sr")
+Game.create!(name: "Metroid Prime", slug: "metroid_prime", info: "It's Metroid Prime! The game featuring Samus and the Metroid Prime!")
+Game.create!(name: "Ori and the Blind Forest: Definitive Edition", slug: "ori_bf_de", info: "It's Ori and the Blind Forest: Definitive Edition! How informative!")
+Game.create!(name: "Metroid 2: Samus Returns", slug: "metroid_sr", info: "Metroid: Samus Returns for the 3DS. It's divisive, in true Metroid fashion!")
 
 # Set up runcats.
 Runcat.create!(category: "any%", rules: "Beat the game as fast as possible.", game_id: 1)

--- a/test/integration/game_flows_test.rb
+++ b/test/integration/game_flows_test.rb
@@ -16,8 +16,8 @@ class GameFlowsTest < ActionDispatch::IntegrationTest
     assert_template 'games/index'
     game_collection = Game.all
     game_collection.each do |game|
-      assert_select 'a[href=?]', game_path(game), text: game.name
-      assert_select 'a[href=?]', speedruns_path(game.slug), text: "| Runs"
+      assert_select 'a[href=?]', speedruns_path(game.slug), text: game.name
+      assert_select 'a[href=?]', game_path(game), text: "| Game Info"
       assert_select 'a[href=?]', runcats_path(game.slug), text: "| Categories"
       unless @admin.admin?
         assert_select 'a[href=?]', new_game_runcat_path(game.slug), text: "| New Category"
@@ -37,8 +37,8 @@ class GameFlowsTest < ActionDispatch::IntegrationTest
     assert_template 'games/index'
     game_collection = Game.all
     game_collection.each do |game|
-      assert_select 'a[href=?]', game_path(game), text: game.name
-      assert_select 'a[href=?]', speedruns_path(game.slug), text: "| Runs"
+      assert_select 'a[href=?]', speedruns_path(game.slug), text: game.name
+      assert_select 'a[href=?]', game_path(game), text: "| Game Info"
       assert_select 'a[href=?]', runcats_path(game.slug), text: "| Categories"
     end
     assert_no_difference 'Game.count' do


### PR DESCRIPTION
… a game's name will take you to the speedrun leaderboards instaed of the game info page, replacing the 'Runs' link with said info page link. Adds a check in new Speedrun creation to make sure categories for a game exist before a user can submit times. Updates seeds.rb to include game info, which was previously absent. Updates tests to reflect URL updates.