### PR TITLE
Updates gems to patch out security issue with bootstrap-sass. Adjusts…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'listen', '>= 3.0.5', '< 3.2'
 
 group :development, :test do
   gem 'byebug', platform: :mri
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,17 +44,17 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     arel (9.0.0)
-    autoprefixer-rails (9.4.7)
+    autoprefixer-rails (9.4.9)
       execjs
     bcrypt (3.1.12)
     bindex (0.5.0)
-    bootstrap-sass (3.4.0)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     bootstrap-will_paginate (1.0.0)
       will_paginate
     builder (3.2.3)
-    byebug (10.0.2)
+    byebug (11.0.0)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -67,7 +67,7 @@ GEM
     crass (1.0.4)
     erubi (1.8.0)
     execjs (2.7.0)
-    faker (1.9.1)
+    faker (1.9.3)
       i18n (>= 0.7)
     ffi (1.9.25)
     formatador (0.2.5)
@@ -236,7 +236,7 @@ DEPENDENCIES
   sassc-rails
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
+  sqlite3 (~> 1.3.6)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
@@ -244,4 +244,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.16.2
+   1.17.3


### PR DESCRIPTION
… SQLite3 requirements to depend on 1.3.x rather than allowing it to upgrade to 1.4.x which causes a gem load failure.